### PR TITLE
Update @types/jest to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "wrapper"
   ],
   "devDependencies": {
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^27.0.0",
     "@types/node": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,10 +775,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.20":
-  version "26.0.20"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
-  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+"@types/jest@^27.0.0":
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.0.tgz#f1c28f741371739c7cd0e8edb5ed8e67acfa6c35"
+  integrity sha512-IlpQZVpxufe+3qPaAqEoSPHVSxnJh1cf0BqqWHJeKiAUbwnHdmNzjP3ZCWSZSTbmAGXQPNk9QmM3Bif0pR54rg==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"


### PR DESCRIPTION
## Version **27.0.0** of **@types/jest** was just published.

* Package: [repository](https://github.com/DefinitelyTyped/DefinitelyTyped.git), [npm](https://www.npmjs.com/package/@types/jest)
* Current Version: 26.0.20
* Dev: true


The version(`27.0.0`) is **not covered** by your current version range(`^26.0.20`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: